### PR TITLE
fixes #8909 - correct version numbers of dependent modules

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,26 +32,6 @@
        "version_requirement": ">= 1.5.0"
     },
     {
-       "name": "theforeman-concat_native",
-       "version_requirement": ">= 1.5.0"
-    },
-    {
-       "name": "theforeman-dhcp",
-       "version_requirement": ">= 1.5.0"
-    },
-    {
-       "name": "theforeman-dns",
-       "version_requirement": ">= 1.5.0"
-    },
-    {
-       "name": "theforeman-puppet",
-       "version_requirement": ">= 1.5.0"
-    },
-    {
-       "name": "theforeman-tftp",
-       "version_requirement": ">= 1.5.0"
-    },
-    {
        "name": "katello-common",
        "version_requirement": ">= 0.0.1"
     }


### PR DESCRIPTION
Librarian won't update katello-installer's capsule module because metadata.json are referencing versions which don't exist, for example, the latest theforeman-dns is 1.4.  Not sure how it worked before?

Anyway, we don't need them here, Librarian should pull in the dependencies based on `theforeman-foreman_proxy`.
