### PR TITLE
refs #9102 - enabled trusted hosts for capsule and parent FQDN's

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -278,10 +278,11 @@ class capsule (
     freeipa_remove_dns    => $freeipa_remove_dns,
     register_in_foreman   => $register_in_foreman,
     foreman_base_url      => $foreman_url,
+    trusted_hosts         => [$parent_fqdn, $capsule_fqdn],
     registered_proxy_url  => "https://${capsule_fqdn}:${capsule::foreman_proxy_port}",
     oauth_effective_user  => $foreman_oauth_effective_user,
     oauth_consumer_key    => $foreman_oauth_key,
-    oauth_consumer_secret => $foreman_oauth_secret
+    oauth_consumer_secret => $foreman_oauth_secret,
   }
 
   if $pulp or $reverse_proxy_real {


### PR DESCRIPTION
Requires https://github.com/theforeman/smart-proxy/pull/252