### PR TITLE
refs #8175 - configure dispatch router on pulp and pulp nodes

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,5 +11,6 @@ fixtures:
     xinetd:        "git://github.com/puppetlabs/puppetlabs-xinetd.git"
     common:        "git://github.com/katello/puppet-common.git"
     certs:         "git://github.com/katello/puppet-certs.git"
+    qpid:          "git://github.com/katello/puppet-qpid.git"
   symlinks:
     capsule: "#{source_dir}"

--- a/manifests/dispatch_router.pp
+++ b/manifests/dispatch_router.pp
@@ -1,0 +1,74 @@
+# == Class: capsule::dispatch_router
+#
+# Install and configure Qpid Dispatch Router
+#
+class capsule::dispatch_router (
+) {
+
+  class { 'qpid::router': }
+
+  # SSL Certificate Configuration
+  class { 'certs::qpid_router':
+    require => Class['qpid::router::install'],
+  } ~>
+  qpid::router::ssl_profile { 'client':
+    ca   => $certs::ca_cert,
+    cert => $certs::qpid_router::client_cert,
+    key  => $certs::qpid_router::client_key,
+  } ~>
+  qpid::router::ssl_profile { 'server':
+    ca   => $certs::ca_cert,
+    cert => $certs::qpid_router::server_cert,
+    key  => $certs::qpid_router::server_key,
+  }
+
+  # Listen for katello-agent clients
+  qpid::router::listener { 'clients':
+    addr        => $capsule::qpid_router_agent_addr,
+    port        => $capsule::qpid_router_agent_port,
+    ssl_profile => 'server',
+  }
+
+  # Act as hub if pulp master, otherwise connect to hub
+  if $capsule::pulp_master {
+    qpid::router::listener {'hub':
+      addr        => $capsule::qpid_router_hub_addr,
+      port        => $capsule::qpid_router_hub_port,
+      role        => 'inter-router',
+      ssl_profile => 'server',
+    }
+
+    # Connect dispatch router to the local qpid
+    qpid::router::connector { 'broker':
+      addr        => $capsule::qpid_router_broker_addr,
+      port        => $capsule::qpid_router_broker_port,
+      ssl_profile => 'client',
+      role        => 'on-demand',
+    }
+
+    qpid::router::link_route_pattern { 'broker-pulp-route':
+      prefix    => 'pulp.',
+      connector => 'broker',
+    }
+
+    qpid::router::link_route_pattern { 'broker-qmf-route':
+      prefix    => 'qmf.',
+      connector => 'broker',
+    }
+  } else {
+    qpid::router::connector { 'hub':
+      addr        => $capsule::parent_fqdn,
+      port        => $capsule::qpid_router_hub_port,
+      ssl_profile => 'client',
+      role        => 'inter-router',
+    }
+
+    qpid::router::link_route_pattern { 'hub-pulp-route':
+      prefix    => 'pulp.',
+    }
+
+    qpid::router::link_route_pattern { 'hub-qmf-route':
+      prefix    => 'qmf.',
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,4 +78,12 @@ class capsule::params {
   $certs_tar = undef
 
   $rhsm_url = '/rhsm'
+
+  $qpid_router             = true
+  $qpid_router_hub_addr    = '0.0.0.0'
+  $qpid_router_agent_addr  = '0.0.0.0'
+  $qpid_router_broker_addr = $::fqdn
+  $qpid_router_hub_port    = 5646
+  $qpid_router_agent_port  = 5647
+  $qpid_router_broker_port = 5671
 }

--- a/metadata.json
+++ b/metadata.json
@@ -34,6 +34,9 @@
     {
        "name": "katello-common",
        "version_requirement": ">= 0.0.1"
+    },
+    {  "name": "katello-qpid",
+       "version_requirement": ">= 1.0.0"
     }
   ]
 }


### PR DESCRIPTION
Requires ~~https://github.com/Katello/puppet-certs/pull/51~~ and ~~https://github.com/Katello/puppet-qpid/pull/15~~ and ~~https://github.com/Katello/puppet-qpid/pull/17~~