### PR TITLE
fixes #10387 - set apache certs properly on crane module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,11 @@
 fixtures:
   repositories:
+    apache:        "git://github.com/puppetlabs/puppetlabs-apache.git"
     stdlib:        "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    concat:        "git://github.com/theforeman/puppet-concat"
+    concat:
+      repo: "git://github.com/puppetlabs/puppetlabs-concat.git"
+      branch: "1.2.x"
+    concat_native: "git://github.com/theforeman/puppet-concat_native.git"
     foreman_proxy: "git://github.com/theforeman/puppet-foreman_proxy.git"
     dhcp:          "git://github.com/theforeman/puppet-dhcp"
     dns:           "git://github.com/theforeman/puppet-dns"
@@ -13,5 +17,7 @@ fixtures:
     certs:         "git://github.com/katello/puppet-certs.git"
     qpid:          "git://github.com/katello/puppet-qpid.git"
     crane:         "git://github.com/katello/puppet-crane.git"
+    pulp:          "git://github.com/katello/puppet-pulp.git"
+    mongodb:       "git://github.com/puppetlabs/puppetlabs-mongodb.git"
   symlinks:
     capsule: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
@@ -17,12 +16,6 @@ env:
   - PUPPET_VERSION="~> 3.6.0"
 matrix:
   exclude:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.2.0"
   - rvm: 2.1.0

--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,10 @@
     {
        "name": "katello-crane",
        "version_requirement": ">= 0.1.0"
+    },
+    {
+       "name": "katello-certs",
+       "version_requirement": ">= 0.1.0"
     }
   ]
 }

--- a/spec/classes/capsule_spec.rb
+++ b/spec/classes/capsule_spec.rb
@@ -20,4 +20,31 @@ describe 'capsule' do
     it { should contain_class('capsule::install') }
   end
 
+  context 'with pulp' do
+    let :facts do
+      {
+        :concat_basedir             => '/tmp',
+        :operatingsystem            => 'RedHat',
+        :operatingsystemrelease     => '6.4',
+        :operatingsystemmajrelease  => '6.4',
+        :osfamily                   => 'RedHat',
+      }
+    end
+
+    let(:params) do
+      {
+        :pulp              => true,
+        :pulp_oauth_secret => 'mysecret',
+        :qpid_router       => false
+      }
+    end
+
+    let(:pre_condition) do
+      ['include certs']
+    end
+
+    it { should contain_class('crane').with( {'key' => '/etc/pki/katello/private/katello-apache.key',
+                                              'cert' => '/etc/pki/katello/certs/katello-apache.crt'} ) }
+  end
+
 end


### PR DESCRIPTION
due to an ordering issue the apache certs were not being set properly
splitting up this class would likely make the fix more declarative (as this is
a fairly imperative fix).  I have written a unit test to make sure we do not
regress.