### PR TITLE
Fixes #10675 - templates plugin enabled by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,7 @@ class capsule::params {
   $freeipa_remove_dns            = $foreman_proxy::params::freeipa_remove_dns
 
   # Templates proxy
-  $templates                     = false
+  $templates                     = true
 
   $register_in_foreman = false
   $certs_tar = undef


### PR DESCRIPTION
Otherwise indirect provisioning does not work. The template renders fine.