### PR TITLE
refs #10675 - templates plugin should not be enabled by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,7 +77,7 @@ class capsule::params {
   $freeipa_remove_dns            = $foreman_proxy::params::freeipa_remove_dns
 
   # Templates proxy
-  $templates                     = true
+  $templates                     = false
 
   $register_in_foreman = false
   $certs_tar = undef


### PR DESCRIPTION
Reverts Katello/puppet-capsule#48.  The problem is this now turns the Templates proxy on for Katello, too, so it unnecessarily proxies the unattended URL's, and makes our firewall docs incorrect about what ports go where.

It could be added to the capsule-installer command here: https://github.com/Katello/katello-installer/blob/master/hooks/post/10-post_install.rb#L63

Or if the capsule puppet module can have a way to know if its integrated or not, it can turn these things on by default.

Thoughts?