### PR TITLE
fixes #11338 - use asymmetric routing for pulp/pulp.task queues

### DIFF
--- a/manifests/dispatch_router.pp
+++ b/manifests/dispatch_router.pp
@@ -49,6 +49,13 @@ class capsule::dispatch_router (
 
     qpid::router::link_route_pattern { 'broker-pulp-route':
       prefix    => 'pulp.',
+      direction => 'out',
+      connector => 'broker',
+    }
+
+    qpid::router::link_route_pattern { 'broker-pulp-task-route':
+      prefix    => 'pulp.task',
+      direction => 'in',
       connector => 'broker',
     }
 


### PR DESCRIPTION
Do not merge yet, we need new packages first.