### PR TITLE
Fixes #11660 - use default CA for client certificates verification

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -309,7 +309,7 @@ class capsule (
     class { '::crane':
       cert    => $certs::apache::apache_cert,
       key     => $certs::apache::apache_key,
-      ca_cert => $certs::katello_server_ca_cert,
+      ca_cert => $certs::ca_cert,
       require => Class['certs::apache'],
     }
   }

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -22,7 +22,7 @@ class capsule::reverse_proxy (
     ssl_proxyengine   => true,
     ssl_cert          => $certs::apache::apache_cert,
     ssl_key           => $certs::apache::apache_key,
-    ssl_ca            => $certs::katello_server_ca_cert,
+    ssl_ca            => $certs::ca_cert,
     ssl_verify_client => 'optional',
     ssl_verify_depth  => 10,
     request_headers   => ['set X_RHSM_SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"'],
@@ -41,7 +41,7 @@ class capsule::reverse_proxy (
       },
     ],
     custom_fragment   => "
-      SSLProxyCACertificateFile ${::certs::katello_server_ca_cert}
+      SSLProxyCACertificateFile ${::certs::ca_cert}
       SSLProxyMachineCertificateFile ${certs::foreman_proxy::foreman_proxy_ssl_client_bundle}
     ",
   }


### PR DESCRIPTION
The katello_server_ca_cert is not meant to verify client certificates
(although it seems to work with all-in-one certificates).