### PR TITLE
Fixes #14534 - ensure we install client-bootstrap

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class capsule (
     false => '443'
   }
 
-  package{ ['katello-debug']:
+  package{ ['katello-debug', 'katello-client-bootstrap']:
     ensure => installed,
   }
 

--- a/spec/classes/capsule_spec.rb
+++ b/spec/classes/capsule_spec.rb
@@ -14,6 +14,7 @@ describe 'capsule' do
     end
 
     it { should contain_package('katello-debug') }
+    it { should contain_package('katello-client-bootstrap') }
   end
 
   context 'with pulp' do


### PR DESCRIPTION
The client-bootstrap lands in /var/www/html/pub and is needed on the
capsule for clients without access top to the Foreman server