### PR TITLE
Fixes #14602 - Select Puppet::server_implementation from installer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,10 @@
 #                                       the apache vhost to set up a proxy for all
 #                                       certificates pointing to the value.
 #
+# $puppet_server_implementation::       Select which Puppet server implementation to use:
+#                                       Default is the apache passenger implementation.
+#                                       Set this value to 'puppetserver' to use the JVM puppetserver implementation.
+#
 # $reverse_proxy::                      Add reverse proxy to the parent
 #                                       type:boolean
 #
@@ -50,30 +54,31 @@
 #                                       type:boolean
 #
 class capsule (
-  $parent_fqdn               = $capsule::params::parent_fqdn,
-  $certs_tar                 = $capsule::params::certs_tar,
-  $pulp_master               = $capsule::params::pulp_master,
-  $pulp_admin_password       = $capsule::params::pulp_admin_password,
-  $pulp_oauth_effective_user = $capsule::params::pulp_oauth_effective_user,
-  $pulp_oauth_key            = $capsule::params::pulp_oauth_key,
-  $pulp_oauth_secret         = $capsule::params::pulp_oauth_secret,
+  $parent_fqdn                  = $capsule::params::parent_fqdn,
+  $certs_tar                    = $capsule::params::certs_tar,
+  $pulp_master                  = $capsule::params::pulp_master,
+  $pulp_admin_password          = $capsule::params::pulp_admin_password,
+  $pulp_oauth_effective_user    = $capsule::params::pulp_oauth_effective_user,
+  $pulp_oauth_key               = $capsule::params::pulp_oauth_key,
+  $pulp_oauth_secret            = $capsule::params::pulp_oauth_secret,
 
-  $puppet                    = $capsule::params::puppet,
-  $puppet_ca_proxy           = $capsule::params::puppet_ca_proxy,
+  $puppet                       = $capsule::params::puppet,
+  $puppet_ca_proxy              = $capsule::params::puppet_ca_proxy,
+  $puppet_server_implementation = $capsule::params::puppet_server_implementation,
 
-  $reverse_proxy             = $capsule::params::reverse_proxy,
-  $reverse_proxy_port        = $capsule::params::reverse_proxy_port,
+  $reverse_proxy                = $capsule::params::reverse_proxy,
+  $reverse_proxy_port           = $capsule::params::reverse_proxy_port,
 
-  $rhsm_url                  = $capsule::params::rhsm_url,
+  $rhsm_url                     = $capsule::params::rhsm_url,
 
-  $qpid_router               = $capsule::params::qpid_router,
-  $qpid_router_hub_addr      = $capsule::params::qpid_router_hub_addr,
-  $qpid_router_hub_port      = $capsule::params::qpid_router_hub_port,
-  $qpid_router_agent_addr    = $capsule::params::qpid_router_agent_addr,
-  $qpid_router_agent_port    = $capsule::params::qpid_router_agent_port,
-  $qpid_router_broker_addr   = $capsule::params::qpid_router_broker_addr,
-  $qpid_router_broker_port   = $capsule::params::qpid_router_broker_port,
-  $enable_ostree             = $capsule::params::enable_ostree,
+  $qpid_router                  = $capsule::params::qpid_router,
+  $qpid_router_hub_addr         = $capsule::params::qpid_router_hub_addr,
+  $qpid_router_hub_port         = $capsule::params::qpid_router_hub_port,
+  $qpid_router_agent_addr       = $capsule::params::qpid_router_agent_addr,
+  $qpid_router_agent_port       = $capsule::params::qpid_router_agent_port,
+  $qpid_router_broker_addr      = $capsule::params::qpid_router_broker_addr,
+  $qpid_router_broker_port      = $capsule::params::qpid_router_broker_port,
+  $enable_ostree                = $capsule::params::enable_ostree,
 ) inherits capsule::params {
   validate_bool($enable_ostree)
 
@@ -209,6 +214,7 @@ class capsule (
     class { '::puppet':
       server                      => true,
       server_ca                   => $::foreman_proxy::puppetca,
+      server_implementation       => $puppet_server_implementation,
       server_foreman_url          => $foreman_url,
       server_foreman_ssl_cert     => $::certs::puppet::client_cert,
       server_foreman_ssl_key      => $::certs::puppet::client_key,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,8 +7,9 @@ class capsule::params {
   $reverse_proxy      = false
   $reverse_proxy_port = 8443
 
-  $puppet             = false
-  $puppet_ca_proxy    = undef
+  $puppet                       = false
+  $puppet_ca_proxy              = undef
+  $puppet_server_implementation = 'master'
 
   $certs_tar = undef
   $rhsm_url = '/rhsm'


### PR DESCRIPTION
Adds the possibility to select the `puppet::server_implementation` via the `katello-installer` (name of the option is `--capsule-puppet-server-implementation 'puppetmaster'`.

By default the usual passenger configuration is used.

The `puppetmaster` is configured with the defaults of the `theforeman/puppet-puppet` module (e.g. 2GB of RAM for the JVM).