### PR TITLE
Only disable passenger on pub if passenger is present

### DIFF
--- a/templates/httpd_pub.erb
+++ b/templates/httpd_pub.erb
@@ -1,7 +1,9 @@
 alias /pub /var/www/html/pub
 
 <Location /pub>
-  PassengerEnabled off
+  <IfModule mod_passenger.c>
+    PassengerEnabled off
+  </IfModule>
   Options +FollowSymLinks +Indexes
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Require all granted


### PR DESCRIPTION
As puppet 4 no longer uses passenger, passenger isn't present
and this errors out:

AH00526: Syntax ierror on line 31 of /etc/httpd/conf.d/05-capsule.conf:
Invalid command 'PassengerEnabled', perhaps misspelled or defined by a
module not included in the server configuration