### PR TITLE
Crane needs configuration of SSL certs separate from pulp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,13 @@ class capsule (
         require => Class['pulp'],
       }
     }
+
+    class { '::pulp::crane':
+      cert    => $certs::apache::apache_cert,
+      key     => $certs::apache::apache_key,
+      ca_cert => $certs::ca_cert,
+      require => Class['certs::apache'],
+    }
   }
 
   if $pulp {
@@ -177,7 +184,6 @@ class capsule (
       ssl_cert_name          => 'broker',
     } ~>
     class { '::pulp':
-      enable_crane              => true,
       enable_rpm                => true,
       enable_puppet             => true,
       enable_docker             => true,


### PR DESCRIPTION
On the Katello, pulp is `manage_apache => false` and uses it's own
CA.  On a capsule, pulp is `manage_apache => true` and uses our
apache certs.  So, we need to configure crane directly to use
apache certs in all cases.  Currently on a Katello it's using the Pulp
certs which causes all kinds of problems.

This fixes BATS.  

Eventually we need to figure out how to standardize
the pulp configurations so they're more similar.  If we do that, we can
go back to configuring crane through the pulp top class.
